### PR TITLE
Refactor SHAB data scripts for robustness and clarity

### DIFF
--- a/Shab-Analyse.Rmd
+++ b/Shab-Analyse.Rmd
@@ -59,6 +59,20 @@ library(scales)
 library(tidyr)
 library(tidytext)
 source("get_shab_data.R")
+
+calc_confidence_interval <- function(proportion, total, alpha = 0.05) {
+  if (is.na(total) || total == 0 || is.na(proportion) || proportion < 0 || proportion > 1) {
+    return(c(NA_real_, NA_real_))
+  }
+  # If proportion is 0 or 1, std_error will be 0. qnorm(..., sd = 0) correctly returns the mean.
+  std_error <- sqrt((proportion * (1 - proportion)) / total)
+  if (is.na(std_error)) { # Should be covered by initial checks, but as a safeguard
+      return(c(NA_real_, NA_real_))
+  }
+  lower_bound <- qnorm(alpha / 2, mean = proportion, sd = std_error)
+  upper_bound <- qnorm(1 - alpha / 2, mean = proportion, sd = std_error)
+  return(c(lower_bound, upper_bound))
+}
 ```
 
 
@@ -141,7 +155,7 @@ plot_cumulative <- ggplot(monthly_counts, aes(x = as.Date(paste0(year_month, "-0
   theme(legend.position = "none")
 
 # Create the log scale plot without the legend
-plot_log_scale <- ggplot(monthly_counts, aes(x = as.Date(paste0(year_month, "-01")))) +
+plot_log_scale <- ggplot(monthly_counts %>% dplyr::filter(cumulative_total > 0), aes(x = as.Date(paste0(year_month, "-01")))) +
   geom_line(aes(y = cumulative_total, color = "Cumulative Total")) +
   scale_y_log10() +
   labs(title = "Cumulatives Total auf Zeit (Log Scale)",
@@ -212,7 +226,7 @@ p <- ggplot(final_data, aes(x = year_month)) +
   )
 
 # Add Netto Zuwachs as a separate bar without stacking
-p + geom_col(data = final_data, aes(x = year_month, y = NettoZuwachs, fill = "Netto Zuwachs"), width = 0.3, color = "black", position = position_dodge(width = 0.9))
+p + geom_col(data = final_data, aes(x = year_month, y = NettoZuwachs, fill = "Netto Zuwachs"), width = 0.3, color = "black")
 ```
 
 ```{r Nettozuwachs_nach_Kanton}
@@ -267,7 +281,7 @@ p <- ggplot(final_data_kanton, aes(x = kanton)) +
   )
 
 # Add Netto Zuwachs as a separate bar without stacking
-p + geom_col(data = final_data_kanton, aes(x = kanton, y = NettoZuwachs, fill = "Netto Zuwachs"), width = 0.3, color = "black", position = position_dodge(width = 0.9))
+p + geom_col(data = final_data_kanton, aes(x = kanton, y = NettoZuwachs, fill = "Netto Zuwachs"), width = 0.3, color = "black")
 ```
 ```{r Prozentuale_Verteilung}
 # Calculate relative contributions of HR01 and HR03
@@ -286,22 +300,14 @@ ordered_kantons <- relative_contribution %>%
 relative_contribution <- relative_contribution %>%
   mutate(kanton = factor(kanton, levels = ordered_kantons))
 
-dp <- 1
-relative_contribution2 <- relative_contribution %>%
-  arrange(kanton, subrubric) %>%
-  group_by(kanton) %>%
-  mutate(y_text = percentage[2] + c(1, -1) * dp)
-
-ggplot(relative_contribution2, aes(x = kanton, y = percentage, fill = subrubric)) +
+ggplot(relative_contribution, aes(x = kanton, y = percentage, fill = subrubric)) +
   geom_col(color = "black") +  
-  coord_cartesian(ylim = c(30, 50)) + 
   
   # Labels for HR01 at the bottom of the bars
-  geom_text(
-    aes(label = round(percentage, 1), y = y_text), 
-    size = 3, 
-    color = "black"
-  ) +
+  geom_text(aes(label = ifelse(percentage > 5, paste0(round(percentage, 1), "%"), "")),
+            position = position_stack(vjust = 0.5),
+            size = 3,
+            color = "black") +
 
   labs(
     title = "Prozentuale Verteilung von Neueintragung und Löschungen nach Kanton",
@@ -474,12 +480,7 @@ monthly_counts_prop <- monthly_counts_prop %>%
 
 alpha <- 0.05  # 95% confidence level
 
-calc_confidence_interval <- function(proportion, total) {
-  std_error <- sqrt((proportion * (1 - proportion)) / total)  
-  lower_bound <- qnorm(alpha / 2, mean = proportion, sd = std_error)
-  upper_bound <- qnorm(1 - alpha / 2, mean = proportion, sd = std_error)
-  return(c(lower_bound, upper_bound))
-}
+# calc_confidence_interval is now defined in lade_libraries chunk
 
 monthly_counts_prop <- monthly_counts_prop %>%
   rowwise() %>%
@@ -518,12 +519,7 @@ data_summary <- data %>%
          proportion = HR01 / total)
 
 # Step 3: Define the function to calculate the confidence interval for proportions
-calc_confidence_interval <- function(proportion, total, alpha = 0.05) {
-  std_error <- sqrt((proportion * (1 - proportion)) / total)  # standard error
-  lower_bound <- proportion - qnorm(1 - alpha / 2) * std_error
-  upper_bound <- proportion + qnorm(1 - alpha / 2) * std_error
-  return(c(lower_bound, upper_bound))
-}
+# calc_confidence_interval is now defined in lade_libraries chunk
 
 # Step 4: Apply the confidence interval function for each canton/quarter combination
 data_summary <- data_summary %>%
@@ -654,12 +650,12 @@ library(ggplot2)
 library(dplyr)
 library(patchwork)
 
-hr03_data <- subset(data, subrubric == "HR03" & year >= 2020)
+hr03_data <- subset(data, subrubric == "HR03" & as.numeric(year) >= 2020)
 hr03_counts <- hr03_data %>%
   group_by(year, month) %>%
   summarise(count = n(), .groups = 'drop')
 
-hr01_data <- subset(data, subrubric == "HR01" & year >= 2020)
+hr01_data <- subset(data, subrubric == "HR01" & as.numeric(year) >= 2020)
 hr01_counts <- hr01_data %>%
   group_by(year, month) %>%
   summarise(count = n(), .groups = 'drop')

--- a/get_shab_data.R
+++ b/get_shab_data.R
@@ -3,8 +3,8 @@
 library(httr)
 library(XML)
 library(dplyr)
+library(tibble) # Add if not present
 
-# Function to get data for a specific date
 Get_Shab_DF <- function(download_date) {
   pickles_folder <- './shab_data'
   if (!dir.exists(pickles_folder)) {
@@ -19,28 +19,65 @@ Get_Shab_DF <- function(download_date) {
   download_date_str <- format(as.Date(download_date), "%Y-%m-%d")
   pickle_file <- file.path(pickles_folder, paste0('shab-', download_date_str, '.RDS'))
   
+  df <- NULL
+
   if (file.exists(pickle_file)) {
     df <- readRDS(pickle_file)
   } else {
-    data <- list()
-    pages <- c(0, 1)
-    for (page in pages) {
-      xmlfile <- file.path(import_folder, paste0('shab_', download_date_str, '_', page + 1, '.xml'))
+    data_list_for_date <- list()
+    current_page <- 0
+    max_results_per_page <- 3000
+
+    repeat {
+      xmlfile <- file.path(import_folder, paste0('shab_', download_date_str, '_', current_page + 1, '.xml'))
       
       url <- paste0('https://amtsblattportal.ch/api/v1/publications/xml?publicationStates=PUBLISHED&tenant=shab&rubrics=HR&rubrics=KK&rubrics=LS&rubrics=NA&rubrics=SR&publicationDate.start=', 
                     download_date_str, '&publicationDate.end=', download_date_str, 
-                    '&pageRequest.size=3000&pageRequest.sortOrders&pageRequest.page=', 
-                    page)
+                    '&pageRequest.size=', max_results_per_page, '&pageRequest.sortOrders&pageRequest.page=',
+                    current_page)
       
-      r <- GET(url)
+      r <- NULL
+      http_error_occurred <- FALSE
+      try_get_result <- try(r <- GET(url), silent = TRUE)
+
+      if (inherits(try_get_result, "try-error")) {
+          cat('Failed GET request for date', download_date_str, 'page', current_page, ':', as.character(try_get_result), '\n')
+          http_error_occurred <- TRUE
+      } else {
+          tryCatch({
+              httr::stop_for_status(r)
+          }, error = function(e) {
+              cat('HTTP error for date', download_date_str, 'page', current_page, ':', e$message, '\n')
+              http_error_occurred <<- TRUE
+          })
+      }
+
+      if(http_error_occurred) {
+          if (file.exists(xmlfile)) { file.remove(xmlfile) }
+          break
+      }
+      
+      if(is.null(r)){
+          cat('GET request did not return a response object for date', download_date_str, 'page', current_page, '\n')
+          if (file.exists(xmlfile)) { file.remove(xmlfile) }
+          break
+      }
+
       writeBin(content(r, "raw"), xmlfile)
       
-      tree <- xmlTreeParse(xmlfile, useInternalNodes = TRUE)
-      root <- xmlRoot(tree)
-      file.remove(xmlfile)
-      
+      publications_on_page <- 0
+      tree <- NULL
       tryCatch({
+        tree <- xmlTreeParse(xmlfile, useInternalNodes = TRUE)
+        root <- xmlRoot(tree)
+
         rls_list <- getNodeSet(root, './publication/meta')
+        if (length(rls_list) == 0) {
+          file.remove(xmlfile)
+          break
+        }
+        publications_on_page <- length(rls_list)
+
         for (rls in rls_list) {
           inner <- list(
             id = xmlValue(rls[['id']]),
@@ -52,84 +89,175 @@ Get_Shab_DF <- function(download_date) {
             primaryTenantCode = xmlValue(rls[['primaryTenantCode']]),
             kanton = xmlValue(rls[['cantons']])
           )
-          data <- append(data, list(inner))
+          data_list_for_date <- append(data_list_for_date, list(inner))
         }
+        file.remove(xmlfile)
       }, error = function(e) {
-        cat('Failed to process', xmlfile, ':', e$message, '\n')
+        cat('Failed to process XML content for date', download_date_str, 'page', current_page, ':', e$message, '\n')
+        if (file.exists(xmlfile)) {
+            file.remove(xmlfile)
+        }
+        break
       })
-    }
+
+      if (publications_on_page < max_results_per_page) {
+        break
+      }
+
+      current_page <- current_page + 1
+      if (current_page > 100) {
+          cat("Warning: Exceeded 100 pages for date", download_date_str, ". Assuming no more data.\n")
+          if (file.exists(xmlfile)) { file.remove(xmlfile) }
+          break
+      }
+    } # end repeat
     
-    df <- bind_rows(data)
+    df <- dplyr::bind_rows(data_list_for_date) # Added dplyr:: for clarity
     if (nrow(df) > 0) {
-      df <- df %>% filter(subrubric == "HR01" | subrubric == "HR03")
+      df <- df %>% dplyr::filter(subrubric == "HR01" | subrubric == "HR03") # Added dplyr::
     }
     
     saveRDS(df, pickle_file)
-  }
+  } # end else (new data download block)
   
-  if (!'date' %in% names(df)) {
-    df$date <- as.Date(NA)
+  expected_cols_spec <- tibble::tibble(
+    id = character(), date = as.Date(character()), title = character(),
+    rubric = character(), subrubric = character(), publikations_status = character(),
+    primaryTenantCode = character(), kanton = character()
+  )
+
+  if (is.null(df)) {
+      df <- expected_cols_spec
+  } else if (nrow(df) > 0) {
+    for (col_name in names(expected_cols_spec)) {
+        if (!col_name %in% names(df)) {
+            df[[col_name]] <- expected_cols_spec[[col_name]][0][NA_integer_]
+        }
+    }
+    if ('date' %in% names(df)) {
+        df$date <- as.Date(df$date)
+    } else {
+        df$date <- as.Date(NA_character_)
+    }
+  } else { # nrow(df) == 0
+    df <- expected_cols_spec
   }
   
   return(df)
 }
 
 Get_Shab_DF_from_range <- function(from_date, to_date) {
-  df_Result <- NULL
+  # Ensure from_date and to_date are Date objects
+  from_date <- as.Date(from_date)
+  to_date <- as.Date(to_date)
+
   main_pickle <- './shab_data/last_df.RDS'
   
-  if (file.exists(main_pickle)) {
-    # Load existing data
-    df_Result <- readRDS(main_pickle)
-    df_Result$date <- as.Date(df_Result$date, format = "%Y-%m-%d")  # Ensure Date type
-    
-    # Check if data range is fully covered
-    max_date <- max(df_Result$date, na.rm = TRUE)
-    min_date <- min(df_Result$date, na.rm = TRUE)
-    
-    if (min_date <= from_date && max_date >= to_date) {
-      # Data is already up-to-date within the range
-      df_Result <- df_Result %>% filter(date >= from_date & date <= to_date)
-      return(df_Result)
-    }
-    
-    # Download data for dates before existing range
-    if (min_date > from_date) {
-      for (date in seq(from_date, min_date - 1, by = "day")) {
-        df <- Get_Shab_DF(date)
-        df$date <- as.Date(df$date, format = "%Y-%m-%d")  # Ensure Date type
-        df_Result <- bind_rows(df_Result, df)
-      }
-    }
-    
-    # Download data for dates after existing range
-    if (max_date < to_date) {
-      for (date in seq(max_date + 1, to_date, by = "day")) {
-        df <- Get_Shab_DF(date)
-        df$date <- as.Date(df$date, format = "%Y-%m-%d")  # Ensure Date type
-        df_Result <- bind_rows(df_Result, df)
-      }
-    }
-    
-    # Save updated data
-    saveRDS(df_Result, main_pickle)
-    return(df_Result)
-    
-  } else {
-    # If no existing data, download full range
-    for (date in seq(from_date, to_date, by = "day")) {
-      df <- Get_Shab_DF(date)
-      df$date <- as.Date(df$date, format = "%Y-%m-%d")  # Ensure Date type
-      if (is.null(df_Result)) {
-        df_Result <- df
-      } else {
-        df_Result <- bind_rows(df_Result, df)
-      }
-    }
-    # Save the full range data
-    saveRDS(df_Result, main_pickle)
-    return(df_Result)
+  # Helper to get a standard empty dataframe structure
+  get_empty_df_structure <- function() {
+    # Use a known date (like today or from_date) just to get the structure from Get_Shab_DF
+    # Get_Shab_DF is guaranteed to return a correctly structured tibble (possibly empty)
+    temp_date_for_struct <- if (!is.na(from_date)) from_date else Sys.Date()
+    empty_df <- Get_Shab_DF(temp_date_for_struct)
+    return(empty_df[0, ]) # Return 0 rows, but with correct columns and types
   }
+
+  df_Result <- NULL
+
+  if (file.exists(main_pickle)) {
+    df_Result <- readRDS(main_pickle)
+    
+    # Validate and standardize df_Result
+    if (is.null(df_Result) || !is.data.frame(df_Result) || ncol(df_Result) == 0) {
+      df_Result <- get_empty_df_structure()
+    } else {
+      # Ensure 'date' column exists and is Date type
+      if (!'date' %in% names(df_Result)) {
+        df_Result$date <- as.Date(NA_character_)
+      } else {
+        df_Result$date <- as.Date(df_Result$date)
+      }
+      # Ensure all other expected columns are present (important if old RDS format differs)
+      expected_cols <- names(get_empty_df_structure())
+      for(col_name in expected_cols){
+          if(!col_name %in% names(df_Result)){
+              df_Result[[col_name]] <- get_empty_df_structure()[[col_name]][0][NA_integer_]
+          }
+      }
+      # Select columns in expected order to ensure consistency
+      df_Result <- df_Result[, expected_cols, drop = FALSE]
+    }
+  } else {
+    df_Result <- get_empty_df_structure()
+  }
+
+  min_existing_date <- if (nrow(df_Result) > 0 && any(!is.na(df_Result$date))) min(df_Result$date, na.rm = TRUE) else NA
+  max_existing_date <- if (nrow(df_Result) > 0 && any(!is.na(df_Result$date))) max(df_Result$date, na.rm = TRUE) else NA
+
+  # Check for full coverage if existing data is valid
+  if (!is.na(min_existing_date) && !is.na(max_existing_date) &&
+      min_existing_date <= from_date && max_existing_date >= to_date) {
+    # Already covered, just filter and return
+    return(df_Result %>% dplyr::filter(date >= from_date & date <= to_date))
+  }
+
+  new_data_list <- list()
+  dates_to_fetch <- c()
+
+  # Determine dates to fetch before existing data
+  dates_to_prepend <- c()
+  if (is.na(min_existing_date) || min_existing_date > from_date) {
+    actual_end_prepend <- if (is.na(min_existing_date)) to_date else min(to_date, min_existing_date - 1)
+    if (actual_end_prepend >= from_date) {
+      dates_to_prepend <- seq(from_date, actual_end_prepend, by = "day")
+    }
+  }
+
+  # Determine dates to fetch after existing data
+  dates_to_append <- c()
+  if (is.na(max_existing_date) || max_existing_date < to_date) {
+    actual_start_append <- if (is.na(max_existing_date)) from_date else max(from_date, max_existing_date + 1)
+    if (to_date >= actual_start_append) {
+      dates_to_append <- seq(actual_start_append, to_date, by = "day")
+    }
+  }
+
+  all_dates_to_fetch <- unique(c(dates_to_prepend, dates_to_append))
+
+  if (length(all_dates_to_fetch) > 0) {
+    for (date_val in sort(all_dates_to_fetch)) {
+      df_day <- Get_Shab_DF(date_val)
+      if (nrow(df_day) > 0) {
+        new_data_list[[length(new_data_list) + 1]] <- df_day
+      }
+    }
+  }
+
+  if (length(new_data_list) > 0) {
+    new_data_combined <- dplyr::bind_rows(new_data_list)
+    # Ensure df_Result is a valid tibble for bind_rows
+    if (nrow(df_Result) == 0 && ncol(df_Result) == 0 && !("tbl_df" %in% class(df_Result)) ){
+        df_Result <- get_empty_df_structure()
+    } else if (!identical(sapply(df_Result, class), sapply(get_empty_df_structure(), class))){
+        # Coerce df_Result to expected structure if classes mismatch (e.g. old RDS format)
+        # This is a bit aggressive; assumes column names are compatible for conversion by bind_rows
+        # A more robust way might be to select common columns or convert types individually.
+        # For now, rely on Get_Shab_DF's consistency and previous standardization of df_Result.
+    }
+
+    df_Result <- dplyr::bind_rows(df_Result, new_data_combined)
+    df_Result <- dplyr::distinct(df_Result, dplyr::across(tidyselect::everything()))
+  }
+
+  # Final filter for the requested date range
+  if (nrow(df_Result) > 0) {
+    df_Result <- df_Result %>% dplyr::filter(date >= from_date & date <= to_date)
+  } else {
+    df_Result <- get_empty_df_structure() # Ensure standard empty if no data in range
+  }
+
+  saveRDS(df_Result, main_pickle)
+  return(df_Result)
 }
 
 


### PR DESCRIPTION
This commit introduces several improvements to the SHAB data fetching and analysis scripts:

get_shab_data.R:
- Enhanced `Get_Shab_DF` to dynamically fetch all pages from the API, replacing the hardcoded 2-page limit.
- Implemented robust HTTP error handling using `stop_for_status()` and safer GET requests.
- Improved XML parsing error handling within `Get_Shab_DF`.
- Ensured `Get_Shab_DF` consistently returns a tibble with a predefined structure, even if a date yields no data or an error occurs.
- Refined `Get_Shab_DF_from_range` for more robust date handling, especially around empty or partially existing data.
- Optimized data accumulation in `Get_Shab_DF_from_range` by collecting daily dataframes in a list and using fewer `bind_rows` calls.
- Added `dplyr::distinct()` after combining data in `Get_Shab_DF_from_range` to prevent duplicates.
- Added `library(tibble)` for explicit tibble usage.

Shab-Analyse.Rmd:
- Consolidated `calc_confidence_interval` function: defined once and made more robust (handles total=0, invalid proportions).
- Made the y-axis of the log-scale cumulative plot (`plot_log_scale`) more robust by filtering for `cumulative_total > 0`.
- Removed `position_dodge` from `NettoZuwachs` bars in monthly and cantonal summary plots to simplify overlay.
- Removed hardcoded `ylim` from `Prozentuale_Verteilung` plot for dynamic scaling.
- Ensured numeric comparison for `year` variable by using `as.numeric()`.
- Improved text labeling in `Prozentuale_Verteilung` plot using `position_stack` and conditional display for clarity.